### PR TITLE
feat: Add Following feed mode

### DIFF
--- a/src/Features/Feed/FollowingFeed.xm
+++ b/src/Features/Feed/FollowingFeed.xm
@@ -1,0 +1,93 @@
+#import <Foundation/Foundation.h>
+#import <substrate.h>
+#import "../../Utils.h"
+
+static NSInteger const IGHomeFeedPickerMenuItemForYou = 0;
+static NSInteger const IGHomeFeedPickerMenuItemFollowing = 5;
+
+static BOOL sciFollowingFeedEnabled(void) {
+    return [[SCIUtils getStringPref:@"main_feed_mode"] isEqualToString:@"following"];
+}
+
+%hook IGHomeFeedPickerMenuController
+- (id)initWithUserSession:(id)userSession menuItems:(NSArray *)menuItems homeFeedViewModel:(id)homeViewModel analyticsModule:(id)analyticsModule navigationController:(id)navigationController isForYouContentLaneEnabled:(BOOL)forYouEnabled {
+    if (!sciFollowingFeedEnabled())
+        return %orig;
+
+    NSMutableArray *items = menuItems.mutableCopy;
+    [items removeObject:@(IGHomeFeedPickerMenuItemFollowing)];
+    [items removeObject:@(IGHomeFeedPickerMenuItemForYou)];
+    [items insertObject:@(IGHomeFeedPickerMenuItemFollowing) atIndex:0];
+    return %orig(userSession, items, homeViewModel, analyticsModule, navigationController, YES);
+}
+- (void)_didSelectItem:(id)item {
+    if (sciFollowingFeedEnabled() && MSHookIvar<NSInteger>(item, "_feed_type") == IGHomeFeedPickerMenuItemFollowing)
+        return;
+    %orig;
+}
+%end
+
+%hook _TtC14IGHomeMainFeed28IGHomeMainFeedViewController
+- (void)viewWillAppear:(BOOL)animated {
+    if (sciFollowingFeedEnabled())
+        MSHookIvar<id>(self, "currentFeedMenuItem") = @(IGHomeFeedPickerMenuItemFollowing);
+    %orig;
+}
+%end
+
+%hook IGHomeFeedHeaderView
+- (void)setTitle:(id)title animated:(BOOL)animated {
+    if (sciFollowingFeedEnabled() && [title isEqual:@"For you"])
+        %orig(@"Following", animated);
+    else
+        %orig;
+}
+%end
+
+%hook _TtC11IGDSAShared18IGDSAGatingManager
+- (NSInteger)feedStickyContentLaneSelection {
+    if (sciFollowingFeedEnabled())
+        return 1;
+    return %orig;
+}
+%end
+
+// `Following` feed uses smaller story tray avatars for some reason; match `For You` feed sizing instead.
+%hook _TtC19IGStoryTrayUIModels24IGStoryTrayCellViewModel
+- (double)avatarSizeAdjustment {
+    if (sciFollowingFeedEnabled())
+        return 28.5;
+    return %orig;
+}
+%end
+
+%hook IGMainFeedViewModel
+- (id)initWithDeps:(id)deps posts:(id)posts nextMaxID:(id)nextMaxID initialPaginationSource:(NSString *)paginationSource contentCoordinator:(id)coordinator dataSourceSupplementaryItemsProvider:(id)supplementaryProvider disableAutomaticRefresh:(BOOL)disableRefresh disableSerialization:(BOOL)disableSerialization sessionId:(id)sessionId analyticsModule:(id)analyticsModule disableFlashFeedTLI:(BOOL)disableFlashFeedTLI disableFlashFeedOnColdStart:(BOOL)disableColdStart disableResponseDeferral:(BOOL)disableResponseDeferral hidesStoriesTray:(BOOL)hidesStoriesTray isSecondaryFeed:(BOOL)isSecondaryFeed collectionViewBackgroundColorOverride:(id)backgroundColor minWarmStartFetchInterval:(double)minWarmStart peakMinWarmStartFetchInterval:(double)peakMinWarmStart minimumWarmStartBackgroundedInterval:(double)backgroundedMinWarmStart peakMinimumWarmStartBackgroundedInterval:(double)peakBackgroundedMinWarmStart supplementalFeedHoistedMediaID:(id)hoistedMediaId headerTitleOverride:(id)headerTitle isInFollowingTab:(BOOL)isInFollowingTab useShimmerLoadingWhenNoStoriesTray:(BOOL)useShimmer mainFeedDataFetcher:(id)dataFetcher {
+    if (sciFollowingFeedEnabled()) {
+        paginationSource = @"following";
+        isInFollowingTab = YES;
+    }
+    return %orig;
+}
+%end
+
+%hook IGMainFeedNetworkSource
+- (id)initWithPosts:(id)posts nextMaxID:(id)nextMaxID initialPaginationSource:(NSString *)paginationSource fetchPath:(id)fetchPath responseParser:(id)responseParser mainFeedNetworkSourceSessionDeps:(id)deps sessionTracker:(id)sessionTracker analyticsModule:(id)analyticsModule useNewUIGraph:(BOOL)useNewGraph {
+    if (sciFollowingFeedEnabled())
+        paginationSource = @"following";
+    return %orig;
+}
+- (void)updatePaginationSource:(id)paginationSource nextMaxID:(id)nextMaxID {
+    if (sciFollowingFeedEnabled())
+        paginationSource = @"following";
+    %orig;
+}
+%end
+
+%hook _TtC24IGMainFeedDataFetcherKit30IGMainFeedRequestConfigFactory
+- (id)generateHeadLoadRequestConfigWithReason:(NSInteger)reason trackingWith:(id)tracking cancelOngoingFetch:(BOOL)cancel hoistedMediaID:(id)hoistedMediaID hoistedMediaShortcode:(id)shortcode deeplinkURL:(id)deeplinkURL isNonFeedSurface:(BOOL)isNonFeedSurface additionalParams:(id)params prewarmConfig:(id)prewarmConfig containerModule:(id)containerModule paginationSource:(id)paginationSource secondaryFeedFilter:(id)secondaryFeedFilter vpvdSeenIds:(id)seenIds {
+    if (sciFollowingFeedEnabled() && [paginationSource isEqual:@"following"])
+        reason = 3;
+    return %orig;
+}
+%end

--- a/src/Settings/TweakSettings.m
+++ b/src/Settings/TweakSettings.m
@@ -213,6 +213,12 @@
                                            subtitle:@""
                                                icon:[SCISymbol symbolWithName:@"rectangle.stack"]
                                         navSections:@[@{
+                                            @"header": SCILocalized(@"Main feed"),
+                                            @"rows": @[
+                                                [SCISetting menuCellWithTitle:SCILocalized(@"Main feed") subtitle:SCILocalized(@"Choose Instagram's default feed or force the Following feed") menu:[self menus][@"main_feed_mode"]],
+                                            ]
+                                        },
+                                        @{
                                             @"header": SCILocalized(@"Action button"),
                                             @"footer": SCILocalized(@"Adds a RyukGram action button under each feed post with download/share/copy/expand/repost entries. Tap opens the menu by default; change the tap behavior below."),
                                             @"rows": @[
@@ -1699,6 +1705,12 @@ static void sciPresentTeenIconPicker(void) {
         @"reels_action_default":   [self defaultTapMenuForKey:@"reels_action_default"   context:@"reels"],
         @"stories_action_default": [self defaultTapMenuForKey:@"stories_action_default" context:@"stories"],
         @"dm_visual_action_default": [self defaultTapMenuForKey:@"dm_visual_action_default" context:@"dm_visual"],
+        @"main_feed_mode": [UIMenu menuWithChildren:@[
+            [UICommand commandWithTitle:SCILocalized(@"Default") image:nil action:@selector(menuChanged:)
+                           propertyList:@{@"defaultsKey": @"main_feed_mode", @"value": @"default", @"requiresRestart": @YES}],
+            [UICommand commandWithTitle:SCILocalized(@"Following") image:nil action:@selector(menuChanged:)
+                           propertyList:@{@"defaultsKey": @"main_feed_mode", @"value": @"following", @"requiresRestart": @YES}],
+        ]],
 
         @"default_video_quality": [UIMenu menuWithChildren:@[
             [UICommand commandWithTitle:SCILocalized(@"Always ask") image:nil action:@selector(menuChanged:)

--- a/src/Tweak.x
+++ b/src/Tweak.x
@@ -73,6 +73,7 @@ static NSDictionary *sciDefaultsDictionary(void) {
         @"disable_bg_refresh": @(NO),
         @"disable_home_refresh": @(NO),
         @"disable_home_scroll": @(NO),
+        @"main_feed_mode": @"default",
         @"disable_reels_tab_refresh": @(NO),
         @"dm_full_last_active": @(NO),
         @"send_file": @(NO),


### PR DESCRIPTION
Hi @faroukbmiled and first of all thank you for this amazing tweak! 🎉 

## Changes

This PR ports my own tweak (https://github.com/n3d1117/InstaSane) into RyukGram. It adds a `Feed > Main` feed picker in Settings with two modes:

- `Default`: preserves Instagram behavior
- `Following`: forces the home feed to default use the _chronological_ `Following` feed

It also:
- Replaces the `For you` header with `Following`
- Keeps feed pagination and refreshes on the `following` source
- Removes `For you` from the feed picker

Tested on Instagram v428.1.0 with the latest `dev` branch.

## Screenshots
| Feed + Picker | Settings |
|---|---|
| <img width="300" src="https://github.com/user-attachments/assets/28ea990c-0266-431f-86d2-7dce2c17393b" /> | <img width="300" src="https://github.com/user-attachments/assets/809741c0-cac0-4a14-86a7-49700f6380a6" /> |
